### PR TITLE
Fix channel entry & preserve wood type meta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ build
 # other
 eclipse
 run
+/Reference

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [2.17.2] - 2026-03-23
+
+### Fixed
 - Fixed normal irrigation channel recipe
 - Fixed normal/full irrigation channel conversion recipes not properly copying NBT
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.17.2] - 2026-03-23
+- Fixed normal irrigation channel recipe
+- Fixed normal/full irrigation channel conversion recipes not properly copying NBT
+
 ## [2.17.1] - 2026-03-16
 
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ show_testing_output = false
 
 # Mod Information
 # HIGHLY RECOMMEND complying with SemVer for mod_version: https://semver.org/
-mod_version = 2.17.1
+mod_version = 2.17.2
 root_package = com.agricraft
 mod_id = agricraft
 mod_name = AgriCraft

--- a/src/main/java/com/infinityraider/agricraft/blocks/irrigation/BlockWaterChannel.java
+++ b/src/main/java/com/infinityraider/agricraft/blocks/irrigation/BlockWaterChannel.java
@@ -125,20 +125,29 @@ public class BlockWaterChannel extends AbstractBlockWaterChannel<TileEntityChann
     @Override
     public void registerRecipes(IForgeRegistry<IRecipe> registry) {
         for (CustomWoodType type : CustomWoodTypeRegistry.getAllTypes()) {
-            NonNullList<Ingredient> ingredients = NonNullList.withSize(9, Ingredient.EMPTY);
+            // Entry recipe: wood planks (xWx / WxW / xWx) -> channel_normal (4x)
+            NonNullList<Ingredient> woodIngredients = NonNullList.withSize(9, Ingredient.EMPTY);
+            for (int i = 0; i <= 8; i++) {
+                if (i % 2 != 0) {
+                    woodIngredients.set(i, Ingredient.fromStacks(type.getStack()));
+                }
+            }
+            ItemStack normalResult = new ItemStack(this, 4, 0);
+            normalResult.setTagCompound(type.writeToNBT(new NBTTagCompound()));
+            registry.register(new CustomWoodShapedRecipe(type, this.getInternalName(), woodIngredients, normalResult));
 
+            // Conversion recipe: channel_normal (xNx / NxN / xNx) -> channel_full (4x)
+            NonNullList<Ingredient> normalIngredients = NonNullList.withSize(9, Ingredient.EMPTY);
             for (int i = 0; i <= 8; i++) {
                 if (i % 2 != 0) {
                     ItemStack stack = new ItemStack(this, 1, 0);
                     stack.setTagCompound(type.writeToNBT(new NBTTagCompound()));
-                    ingredients.set(i, Ingredient.fromStacks(stack));
+                    normalIngredients.set(i, Ingredient.fromStacks(stack));
                 }
             }
-
-            ItemStack result = new ItemStack(AgriBlocks.getInstance().CHANNEL_FULL, 4, 0);
-            result.setTagCompound(type.writeToNBT(new NBTTagCompound()));
-
-            registry.register(new CustomWoodShapedRecipe(type, "normal_to_full", ingredients, result));
+            ItemStack fullResult = new ItemStack(AgriBlocks.getInstance().CHANNEL_FULL, 4, 0);
+            fullResult.setTagCompound(type.writeToNBT(new NBTTagCompound()));
+            registry.register(new CustomWoodShapedRecipe(type, "normal_to_full", normalIngredients, fullResult));
         }
     }
 

--- a/src/main/java/com/infinityraider/agricraft/crafting/CustomWoodShapedRecipe.java
+++ b/src/main/java/com/infinityraider/agricraft/crafting/CustomWoodShapedRecipe.java
@@ -1,7 +1,9 @@
 package com.infinityraider.agricraft.crafting;
 
+import com.infinityraider.agricraft.reference.AgriNBT;
 import com.infinityraider.agricraft.utility.CustomWoodType;
 import infinityraider.infinitylib.Tags;
+import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraft.item.crafting.ShapedRecipes;
@@ -12,6 +14,22 @@ public class CustomWoodShapedRecipe extends ShapedRecipes {
     public CustomWoodShapedRecipe(CustomWoodType type, String name, NonNullList<Ingredient> ingredients, ItemStack result) {
         super("", 3, 3, ingredients, result);
         this.setRegistryName(Tags.MOD_ID, (type + "_" + name).replaceAll(":", "_"));
+    }
+
+    @Override
+    public ItemStack getCraftingResult(InventoryCrafting inv) {
+        ItemStack result = super.getCraftingResult(inv);
+        // Vanilla Ingredient matching ignores NBT, so multiple wood-type recipes all match
+        // the same input. Read the actual material tag from the first tagged input slot and
+        // copy it onto the result so the correct wood type is preserved.
+        for (int i = 0; i < inv.getSizeInventory(); i++) {
+            ItemStack stack = inv.getStackInSlot(i);
+            if (!stack.isEmpty() && stack.hasTagCompound() && stack.getTagCompound().hasKey(AgriNBT.MATERIAL)) {
+                result.setTagCompound(stack.getTagCompound().copy());
+                return result;
+            }
+        }
+        return result;
     }
 
 }


### PR DESCRIPTION
Copy and Preserve channel NBT data, Fixes channels not copying their wood types properly. Takes NBT from first slot.

Fix registering entry recipes for normal channels.
Fixes #4 