### PR TITLE
Water pad creation compatiblity.

### DIFF
--- a/src/main/java/com/infinityraider/agricraft/handler/PlayerInteractEventHandler.java
+++ b/src/main/java/com/infinityraider/agricraft/handler/PlayerInteractEventHandler.java
@@ -5,6 +5,7 @@ import com.infinityraider.agricraft.api.v1.crop.IAgriCrop;
 import com.infinityraider.agricraft.blocks.BlockGrate;
 import com.infinityraider.agricraft.init.AgriBlocks;
 import com.infinityraider.agricraft.reference.AgriCraftConfig;
+import com.infinityraider.agricraft.reference.WaterPadCompatMode;
 import com.infinityraider.agricraft.tiles.TileEntityCrop;
 import com.infinityraider.agricraft.utility.StackHelper;
 import com.infinityraider.infinitylib.utility.MessageUtil;
@@ -122,6 +123,18 @@ public class PlayerInteractEventHandler {
 
         // Test that clicked block was farmland.
         if (block != Blocks.FARMLAND) {
+            return;
+        }
+
+        final WaterPadCompatMode mode = AgriCraftConfig.getWaterPadCompatMode();
+
+        // In trowel-only mode with compatibility.
+        if (!mode.usesShovel()) {
+            return;
+        }
+
+        // In require shift mode the player must be sneaking for the shovel to trigger.
+        if (mode.requiresShift() && !event.getEntityPlayer().isSneaking()) {
             return;
         }
 

--- a/src/main/java/com/infinityraider/agricraft/items/ItemTrowel.java
+++ b/src/main/java/com/infinityraider/agricraft/items/ItemTrowel.java
@@ -131,7 +131,6 @@ public class ItemTrowel extends ItemBase implements IAgriTrowelItem, IItemWithMo
     @SideOnly(Side.CLIENT)
     @Override
     public void addInformation(ItemStack stack, @Nullable World worldIn, List<String> tooltip, ITooltipFlag flag) {
-        tooltip.add(AgriCore.getTranslator().translate("agricraft_tooltip.trowel"));
         if (AgriCraftConfig.getWaterPadCompatMode().usesTrowel()) {
             tooltip.add(AgriCore.getTranslator().translate("agricraft_tooltip.trowel_waterpad"));
         }

--- a/src/main/java/com/infinityraider/agricraft/items/ItemTrowel.java
+++ b/src/main/java/com/infinityraider/agricraft/items/ItemTrowel.java
@@ -75,7 +75,7 @@ public class ItemTrowel extends ItemBase implements IAgriTrowelItem, IItemWithMo
         final WaterPadCompatMode mode = AgriCraftConfig.getWaterPadCompatMode();
         if (mode.usesTrowel()) {
             final IBlockState state = world.getBlockState(pos);
-            if (state.getBlock() == Blocks.FARMLAND) {
+            if (state.getBlock() == Blocks.FARMLAND && !(world.getTileEntity(pos.up()) instanceof IAgriCrop)) {
                 if (!world.isRemote) {
                     world.setBlockState(pos, AgriBlocks.getInstance().WATER_PAD.getDefaultState(), 3);
                     if (!player.capabilities.isCreativeMode) {

--- a/src/main/java/com/infinityraider/agricraft/items/ItemTrowel.java
+++ b/src/main/java/com/infinityraider/agricraft/items/ItemTrowel.java
@@ -2,20 +2,28 @@ package com.infinityraider.agricraft.items;
 
 import com.agricraft.agricore.config.AgriConfigCategory;
 import com.agricraft.agricore.config.AgriConfigurable;
+import com.agricraft.agricore.core.AgriCore;
 import com.google.common.collect.ImmutableList;
 import com.infinityraider.agricraft.api.v1.AgriApi;
 import com.infinityraider.agricraft.api.v1.crop.IAgriCrop;
 import com.infinityraider.agricraft.api.v1.items.IAgriTrowelItem;
 import com.infinityraider.agricraft.api.v1.seed.AgriSeed;
+import com.infinityraider.agricraft.init.AgriBlocks;
 import com.infinityraider.agricraft.items.tabs.AgriTabs;
+import com.infinityraider.agricraft.reference.AgriCraftConfig;
 import com.infinityraider.agricraft.reference.AgriNBT;
+import com.infinityraider.agricraft.reference.WaterPadCompatMode;
 import com.infinityraider.agricraft.utility.StackHelper;
 import com.infinityraider.infinitylib.item.IItemWithModel;
 import com.infinityraider.infinitylib.item.ItemBase;
 import java.util.List;
 import java.util.Optional;
+import javax.annotation.Nullable;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
+import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
@@ -25,6 +33,8 @@ import net.minecraft.util.EnumHand;
 import net.minecraft.util.Tuple;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class ItemTrowel extends ItemBase implements IAgriTrowelItem, IItemWithModel {
 
@@ -60,6 +70,22 @@ public class ItemTrowel extends ItemBase implements IAgriTrowelItem, IItemWithMo
     @Override
     public EnumActionResult onItemUse(EntityPlayer player, World world, BlockPos pos, EnumHand hand, EnumFacing side, float hitx, float hity, float hitz) {
         ItemStack stack = player.getHeldItem(hand);
+
+        // Pass if water pad compat is enabled with trowel mode, create waterpad.
+        final WaterPadCompatMode mode = AgriCraftConfig.getWaterPadCompatMode();
+        if (mode.usesTrowel()) {
+            final IBlockState state = world.getBlockState(pos);
+            if (state.getBlock() == Blocks.FARMLAND) {
+                if (!world.isRemote) {
+                    world.setBlockState(pos, AgriBlocks.getInstance().WATER_PAD.getDefaultState(), 3);
+                    if (!player.capabilities.isCreativeMode) {
+                        stack.damageItem(1, player);
+                    }
+                }
+                return EnumActionResult.SUCCESS;
+            }
+        }
+
         TileEntity te = world.getTileEntity(pos);
         if (te instanceof IAgriCrop) {
             IAgriCrop crop = (IAgriCrop) te;
@@ -100,6 +126,15 @@ public class ItemTrowel extends ItemBase implements IAgriTrowelItem, IItemWithMo
     @Override
     public boolean isEnabled() {
         return enableTrowel;
+    }
+
+    @SideOnly(Side.CLIENT)
+    @Override
+    public void addInformation(ItemStack stack, @Nullable World worldIn, List<String> tooltip, ITooltipFlag flag) {
+        tooltip.add(AgriCore.getTranslator().translate("agricraft_tooltip.trowel"));
+        if (AgriCraftConfig.getWaterPadCompatMode().usesTrowel()) {
+            tooltip.add(AgriCore.getTranslator().translate("agricraft_tooltip.trowel_waterpad"));
+        }
     }
 
     @Override

--- a/src/main/java/com/infinityraider/agricraft/reference/AgriCraftConfig.java
+++ b/src/main/java/com/infinityraider/agricraft/reference/AgriCraftConfig.java
@@ -10,6 +10,7 @@ import com.agricraft.agricore.config.AgriConfigCategory;
 import com.agricraft.agricore.config.AgriConfigurable;
 import com.agricraft.agricore.core.AgriCore;
 import net.minecraft.util.text.TextFormatting;
+import net.minecraftforge.fml.common.Loader;
 
 /**
  * AgriCraft Configuration File.
@@ -132,6 +133,33 @@ public class AgriCraftConfig {
     // Decoration
     @AgriConfigurable(category = AgriConfigCategory.DECORATION, key = "Enable Grates", comment = "Set to false to disable the decorative custom wood grates.")
     public static boolean enableGrates = true;
+
+    // Compatibility
+    @AgriConfigurable(
+            category = AgriConfigCategory.COMPATIBILITY,
+            key = "Water Pad Compat Mode",
+            comment = "Controls how Water Pads can be created when Tea Story is also installed.\n"
+                    + "  none   = Default: shovel right-click on farmland creates a Water Pad.\n"
+                    + "  trowel = Only the AgriCraft trowel creates Water Pads.\n"
+                    + "  shift  = Shovel + Sneak creates a Water Pad.\n"
+                    + "  both   = Trowel OR Shift+Shovel creates a Water Pad.")
+    public static String waterPadCompatMode = "both";
+
+    private static Boolean teaStoryPresent = null;
+
+    public static WaterPadCompatMode getWaterPadCompatMode() {
+        if (teaStoryPresent == null) {
+            teaStoryPresent = Loader.isModLoaded("teastory");
+        }
+        if (!teaStoryPresent) {
+            return WaterPadCompatMode.NONE;
+        }
+        try {
+            return WaterPadCompatMode.valueOf(waterPadCompatMode.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return WaterPadCompatMode.NONE;
+        }
+    }
 
     // Add to Configurator
     static {

--- a/src/main/java/com/infinityraider/agricraft/reference/WaterPadCompatMode.java
+++ b/src/main/java/com/infinityraider/agricraft/reference/WaterPadCompatMode.java
@@ -1,0 +1,34 @@
+package com.infinityraider.agricraft.reference;
+
+/**
+ * Controls how Water Pads can be created via player interaction when in compatibility mode.
+ */
+public enum WaterPadCompatMode {
+
+    NONE,
+    TROWEL,
+    SHIFT,
+    BOTH;
+
+    /**
+     * Whether the shovel event handler is used in Water Pad creation.
+     */
+    public boolean usesShovel() {
+        return this == NONE || this == SHIFT || this == BOTH;
+    }
+
+    /**
+     * Whether the shovel path requires the player to be sneaking.
+     */
+    public boolean requiresShift() {
+        return this == SHIFT || this == BOTH;
+    }
+
+    /**
+     * Whether the trowel should be able to create Water Pads.
+     */
+    public boolean usesTrowel() {
+        return this == TROWEL || this == BOTH;
+    }
+
+}

--- a/src/main/resources/assets/agricraft/lang/cs_cz.lang
+++ b/src/main/resources/assets/agricraft/lang/cs_cz.lang
@@ -88,6 +88,7 @@ agricraft_tooltip.weeds=Zde vyklíčil plevel
 agricraft_tooltip.cropWithoutPlant=Tato rostlina na sobě nemá plod
 agricraft_tooltip.notCrop=Toto není rostlina
 agricraft_tooltip.trowel=Použijte toto pro přesunutí rostliny z jednoho políčka na druhé
+agricraft_tooltip.trowel_waterpad=Klikněte pravým tlačítkem na obdělanou půdu pro vytvoření Vodní podložky
 agricraft_tooltip.magnifyingGlass=Použijte toto pro inspekci rostliny
 agricraft_tooltip.rake=Použijte toto pro odstranění plevelu
 agricraft_tooltip.closed=Zavřeno

--- a/src/main/resources/assets/agricraft/lang/en_us.lang
+++ b/src/main/resources/assets/agricraft/lang/en_us.lang
@@ -88,6 +88,7 @@ agricraft_tooltip.weeds=Weeds have sprouted here
 agricraft_tooltip.cropWithoutPlant=This crop doesn't have a plant on it
 agricraft_tooltip.notCrop=This is not a crop
 agricraft_tooltip.trowel=Use this to move plants from one crop to another
+agricraft_tooltip.trowel_waterpad=Right-click farmland to create a Water Pad
 agricraft_tooltip.magnifyingGlass=Use this to inspect crops
 agricraft_tooltip.rake=Use this to remove weeds from crops
 agricraft_tooltip.closed=Closed

--- a/src/main/resources/assets/agricraft/lang/fr_ca.lang
+++ b/src/main/resources/assets/agricraft/lang/fr_ca.lang
@@ -85,6 +85,7 @@ agricraft_tooltip.weeds=Les mauvaises herbes ont poussées ici
 agricraft_tooltip.cropWithoutPlant=Ce tuteur n'a pas de plante sur lui
 agricraft_tooltip.notCrop=Ceci n'est pas un tuteur
 agricraft_tooltip.trowel=Utilisez-le pour déplacé les plantes d'un tuteur à l'autre
+agricraft_tooltip.trowel_waterpad=Clic droit sur de la terre cultivée pour créer un Coussinet d'eau
 agricraft_tooltip.magnifyingGlass=utilisez-la pour inspecter vos plantes
 agricraft_tooltip.rake=utilisez ceci pour enlever les mauvaises herbes
 agricraft_tooltip.closed=Fermé

--- a/src/main/resources/assets/agricraft/lang/fr_fr.lang
+++ b/src/main/resources/assets/agricraft/lang/fr_fr.lang
@@ -88,6 +88,7 @@ agricraft_tooltip.weeds=Les mauvaises herbes ont poussées ici
 agricraft_tooltip.cropWithoutPlant=Ce tuteur n'a pas de plante sur lui
 agricraft_tooltip.notCrop=Ceci n'est pas un tuteur
 agricraft_tooltip.trowel=Utilisez-le pour déplacé les plantes d'un tuteur à l'autre
+agricraft_tooltip.trowel_waterpad=Clic droit sur de la terre cultivée pour créer un Coussinet d'eau
 agricraft_tooltip.magnifyingGlass=utilisez-la pour inspecter vos plantes
 agricraft_tooltip.rake=utilisez ceci pour enlever les mauvaises herbes
 agricraft_tooltip.closed=Fermé

--- a/src/main/resources/assets/agricraft/lang/pt_BR.lang
+++ b/src/main/resources/assets/agricraft/lang/pt_BR.lang
@@ -88,6 +88,7 @@ agricraft_tooltip.weeds=As ervas daninhas brotaram aqui
 agricraft_tooltip.cropWithoutPlant=Aqui não tem uma planta
 agricraft_tooltip.notCrop=Isso não é uma colheita
 agricraft_tooltip.trowel=Use isso para mover plantas de uma colheita para outra
+agricraft_tooltip.trowel_waterpad=Clique com o botão direito em terra cultivada para criar um Bloco d'Água
 agricraft_tooltip.magnifyingGlass=Use isso para inspecionar os gravetos
 agricraft_tooltip.rake=Use isso para remover ervas daninhas
 agricraft_tooltip.closed=Fechado

--- a/src/main/resources/assets/agricraft/lang/ru_ru.lang
+++ b/src/main/resources/assets/agricraft/lang/ru_ru.lang
@@ -88,6 +88,7 @@ agricraft_tooltip.weeds=Здесь проросли сорняки
 agricraft_tooltip.cropWithoutPlant=На этих жёрдочках нет растений
 agricraft_tooltip.notCrop=Это не жёрдочки
 agricraft_tooltip.trowel=Используется для перемещения растений между жёрдочками
+agricraft_tooltip.trowel_waterpad=Нажмите ПКМ на пашню для создания Водяного помоста
 agricraft_tooltip.magnifyingGlass=Используется для проверки жёрдочек
 agricraft_tooltip.rake=Используются для удаления сорняков с жёрдочек
 agricraft_tooltip.closed=Закрыто

--- a/src/main/resources/assets/agricraft/lang/sv_se.lang
+++ b/src/main/resources/assets/agricraft/lang/sv_se.lang
@@ -82,6 +82,7 @@ agricraft_tooltip.weeds=Weeds have sprouted here
 agricraft_tooltip.cropWithoutPlant=This crop doesn't have a plant on it
 agricraft_tooltip.notCrop=This is not a crop
 agricraft_tooltip.trowel=Use this to move plants from one crop to another
+agricraft_tooltip.trowel_waterpad=Högerklicka på åkermark för att skapa en Vattenkudde
 agricraft_tooltip.magnifyingGlass=Use this to inspect crops
 agricraft_tooltip.rake=Use this to remove weeds from crops
 agricraft_tooltip.closed=Closed

--- a/src/main/resources/assets/agricraft/lang/zh_cn.lang
+++ b/src/main/resources/assets/agricraft/lang/zh_cn.lang
@@ -88,6 +88,7 @@ agricraft_tooltip.weeds=杂草开始在这里生长了
 agricraft_tooltip.cropWithoutPlant=这个作物架是空的
 agricraft_tooltip.notCrop=这不是作物架
 agricraft_tooltip.trowel=用这个把作物从一个作物架上移动到另一个上
+agricraft_tooltip.trowel_waterpad=右键点击耕地以创建水垫
 agricraft_tooltip.magnifyingGlass=用这个来检查作物
 agricraft_tooltip.rake=用这个铲除作物架上的杂草
 agricraft_tooltip.closed=关闭


### PR DESCRIPTION
Most certainly more complicated solution than it needs to be, but I wanted to give people options.

This adds a new config section "compatibility" and a string option "Water Pad Compat Mode" with a default of "both". The setting only applies when Tea Story is installed, growthcraft solved this problem a long time ago, but there may be more mods this feature conflicts with that can be added for later.

Options of None, Trowel, Shift, or Both (Default) can be set. With trowel option adding a tooltip to inform the user of its new use, Shift using the shovel as before but require sneaking, or both. The water pad creation with the trowel checks above it to make sure accidental removal of plot sticks does not occur.

Fixes #8 