### PR TITLE
Increase crop stat cap max allowed value.

### DIFF
--- a/src/main/java/com/infinityraider/agricraft/reference/AgriCraftConfig.java
+++ b/src/main/java/com/infinityraider/agricraft/reference/AgriCraftConfig.java
@@ -21,7 +21,7 @@ public class AgriCraftConfig {
     // Core
     @AgriConfigurable(category = AgriConfigCategory.CORE, key = "Crops per Craft", min = "1", max = "4", comment = "The number of crops you get per crafting operation.")
     public static int cropsPerCraft = 4;
-    @AgriConfigurable(category = AgriConfigCategory.CORE, key = "Crop Stat Cap", min = "1", max = "10", comment = "The maximum attainable value of the stats on a crop.")
+    @AgriConfigurable(category = AgriConfigCategory.CORE, key = "Crop Stat Cap", min = "1", max = "127", comment = "The maximum attainable value of the stats on a crop." + "\nValues higher than 10 have limited benefits, with only additional yield rolls being meaningful, and are not recommended.")
     public static int cropStatCap = 10;
     @AgriConfigurable(category = AgriConfigCategory.CORE, key = "Use boring alpha warning messages", comment = "Uses a boring one-line alpha warning message instead of the more interesting default ones.")
     public static boolean disableLinks = false;


### PR DESCRIPTION
This just changes the max allowed value of the stat cap configuration value. The only real reason to do this is to allow more yield rolls, a note to the option as been added to inform the user of the limited benefits and it not being recommended.

Closes #9 